### PR TITLE
Add a gemhome fact

### DIFF
--- a/lib/facter/gemhome.rb
+++ b/lib/facter/gemhome.rb
@@ -1,0 +1,16 @@
+# Fact: gemhome
+#
+# Purpose: Returns the gem home for rubygems
+#
+# Resolution: Returns GEM_HOME.
+#
+# Caveats:
+#
+begin
+  require 'rubygems'
+
+  Facter.add(:gemhome) do
+    setcode { Gem::dir }
+  end
+rescue LoadError
+end


### PR DESCRIPTION
For manual referencing of gem paths (e.g. in the passenger module), this fact
makes it possible to avoid osfamily/osdistribution guessing.
