### PR TITLE
Update dev packages for Ubuntu/Debian

### DIFF
--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -4,7 +4,7 @@
 #
 # Parameters:
 #   $ruby_dev = the name of the Ruby development libraries
-# 
+#
 # Actions:
 #
 # Requires:
@@ -23,7 +23,7 @@ class ruby::params {
       $rubygems_update  = true
     }
     "debian": {
-      $ruby_dev= [ "ruby-dev", "rake", "irb" ]
+      $ruby_dev= [ "ruby-dev", "rake", "ri" ]
       $rubygems_update  = false
     }
 


### PR DESCRIPTION
remove virtual package irb (which Puppet will constantly try and install) which duplicates the ruby package.

Added `ri` package http://packages.ubuntu.com/quantal/ri which is often required for ruby development.
