### PR TITLE
Add Gentoo support

### DIFF
--- a/.fixtures.yml
+++ b/.fixtures.yml
@@ -1,3 +1,5 @@
 fixtures:
+  repositories:
+    "portage": "git://github.com/gentoo/puppet-portage"
   symlinks:
     "ruby": "#{source_dir}"

--- a/Modulefile
+++ b/Modulefile
@@ -6,3 +6,5 @@ license 'Apache License 2.0'
 summary 'Puppet Labs Ruby Module'
 description 'Ruby Module for Puppet'
 project_page 'https://github.com/puppetlabs/puppetlabs-ruby'
+
+dependency 'gentoo/portage', '2.1.0'

--- a/manifests/dev.pp
+++ b/manifests/dev.pp
@@ -13,7 +13,9 @@
 #
 class ruby::dev {
   require ruby
-  package { $ruby::params::ruby_dev:
-    ensure => installed,
+  if $ruby::params::ruby_dev {
+    package { $ruby::params::ruby_dev:
+      ensure => installed,
+    }
   }
 }

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -66,17 +66,30 @@
 #    }
 #
 class ruby (
-    $version          = $ruby::params::version,
-    $gems_version     = $ruby::params::gems_version,
-    $rubygems_update  = $ruby::params::rubygems_update,
-    $ruby_dev         = $ruby::params::ruby_dev,
-    $ruby_package     = $ruby::params::ruby_package,
-    $rubygems_package = $ruby::params::rubygems_package,
+    $version              = $ruby::params::version,
+    $gems_version         = $ruby::params::gems_version,
+    $rubygems_update      = $ruby::params::rubygems_update,
+    $ruby_dev             = $ruby::params::ruby_dev,
+    $ruby_package         = $ruby::params::ruby_package,
+    $rubygems_package     = $ruby::params::rubygems_package,
+    $ruby_gentoo_keywords = $ruby::params::ruby_gentoo_keywords,
+    $ruby_gentoo_use      = $ruby::params::ruby_gentoo_use,
+    $gems_gentoo_keywords = $ruby::params::gems_gentoo_keywords,
+    $gems_gentoo_use      = $ruby::params::gems_gentoo_use,
 ) inherits ruby::params {
 
-  package { 'ruby':
-    ensure => $version,
-    name   => $ruby_package,
+  if $::operatingsystem == 'gentoo' {
+    portage::package { 'ruby':
+      ensure   => $version,
+      name     => $ruby_package,
+      keywords => $ruby_gentoo_keywords,
+      use      => $ruby_gentoo_use,
+    }
+  } else {
+    package { 'ruby':
+      ensure => $version,
+      name   => $ruby_package,
+    }
   }
 
   # if rubygems_update is set to true then we only need to make the package
@@ -89,10 +102,20 @@ class ruby (
     $rubygems_ensure = $gems_version
   }
 
-  package { 'rubygems':
-    ensure  => $rubygems_ensure,
-    name    => $rubygems_package,
-    require => Package['ruby'],
+  if $::operatingsystem == 'gentoo' {
+    portage::package { 'rubygems':
+      ensure   => $rubygems_ensure,
+      name     => $rubygems_package,
+      require  => Portage::Package['ruby'],
+      keywords => $gems_gentoo_keywords,
+      use      => $gems_gentoo_use,
+    }
+  } else {
+    package { 'rubygems':
+      ensure  => $rubygems_ensure,
+      name    => $rubygems_package,
+      require => Package['ruby'],
+    }
   }
 
   if $rubygems_update {

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -5,17 +5,31 @@
 class ruby::params {
   $version          = 'installed'
   $gems_version     = 'installed'
-  $ruby_package     = 'ruby'
-  $rubygems_package = 'rubygems'
+
+  # Gentoo specific
+  $ruby_gentoo_keywords = ''
+  $ruby_gentoo_use      = ''
+  $gems_gentoo_keywords = ''
+  $gems_gentoo_use      = ''
 
   case $::osfamily {
     'redhat', 'amazon': {
-      $ruby_dev = 'ruby-devel'
-      $rubygems_update = true
+      $ruby_package     = 'ruby'
+      $rubygems_package = 'rubygems'
+      $ruby_dev         = 'ruby-devel'
+      $rubygems_update  = true
     }
     'debian': {
-      $ruby_dev = [ 'ruby-dev', 'rake', 'ri' ]
-      $rubygems_update = false
+      $ruby_package     = 'ruby'
+      $rubygems_package = 'rubygems'
+      $ruby_dev         = [ 'ruby-dev', 'rake', 'ri' ]
+      $rubygems_update  = false
+    }
+    'gentoo': {
+      $ruby_package     = 'dev-lang/ruby'
+      $rubygems_package = 'dev-ruby/rubygems'
+      $ruby_dev         = [ 'dev-ruby/rdoc', 'dev-ruby/rake' ]
+      $rubygems_update  = false
     }
     default: {
       fail("Unsupported OS family: ${::osfamily}")

--- a/spec/classes/init_spec.rb
+++ b/spec/classes/init_spec.rb
@@ -44,6 +44,25 @@ describe 'ruby', :type => :class do
     }
   end
 
+  describe 'when called with no parameters on gentoo' do
+    let (:facts) { { :osfamily => 'Gentoo',
+                     :operatingsystem => 'gentoo',
+                     :path     => '/usr/local/bin:/usr/bin:/bin' } }
+    it {
+      should contain_portage__package('ruby').with({
+        'ensure'  => 'installed',
+        'name'    => 'dev-lang/ruby',
+      })
+      should contain_portage__package('rubygems').with({
+        'ensure'  => 'installed',
+        'name'    => 'dev-ruby/rubygems',
+        'require' => 'Portage::Package[ruby]',
+      })
+      should_not contain_package('rubygems-update')
+      should_not contain_exec('ruby::update_rubygems')
+    }
+  end
+
   describe 'when called with custom rubygems version on redhat' do
     let (:facts) { {   :osfamily  => 'Redhat',
                        :path      => '/usr/local/bin:/usr/bin:/bin' } }
@@ -71,7 +90,7 @@ describe 'ruby', :type => :class do
     }
   end
 
-  describe 'when called with custom ruby package name' do
+  describe 'when called with custom ruby package name on debian' do
     let (:facts) { { :osfamily => 'Debian',
                      :path     => '/usr/local/bin:/usr/bin:/bin' } }
     let (:params) { {  :ruby_package  => 'ruby1.9' } }
@@ -89,7 +108,7 @@ describe 'ruby', :type => :class do
     }
   end
 
-  describe 'when called with custom rubygems package name' do
+  describe 'when called with custom rubygems package name on debian' do
     let (:facts) { { :osfamily => 'Debian',
                      :path     => '/usr/local/bin:/usr/bin:/bin' } }
     let (:params) { { :rubygems_package  => 'rubygems1.9.1' } }
@@ -107,6 +126,43 @@ describe 'ruby', :type => :class do
     }
   end
 
+  describe 'when called with custom ruby package name on gentoo' do
+    let (:facts) { { :osfamily => 'Gentoo',
+                     :operatingsystem => 'gentoo',
+                     :path     => '/usr/local/bin:/usr/bin:/bin' } }
+    let (:params) { {  :ruby_package  => 'dev-lang/ruby-custom' } }
+    it {
+      should contain_portage__package('ruby').with({
+        'ensure'  => 'installed',
+        'name'    => 'dev-lang/ruby-custom',
+      })
+      should contain_portage__package('rubygems').with({
+        'ensure'  => 'installed',
+        'require' => 'Portage::Package[ruby]',
+      })
+      should_not contain_package('rubygems-update')
+      should_not contain_exec('ruby::update_rubygems')
+    }
+  end
+
+  describe 'when called with custom rubygems package name on gentoo' do
+    let (:facts) { { :osfamily => 'Gentoo',
+                     :operatingsystem => 'gentoo',
+                     :path     => '/usr/local/bin:/usr/bin:/bin' } }
+    let (:params) { { :rubygems_package  => 'dev-ruby/rubygems-custom' } }
+    it {
+      should contain_portage__package('ruby').with({
+        'ensure'  => 'installed',
+      })
+      should contain_portage__package('rubygems').with({
+        'name'    => 'dev-ruby/rubygems-custom',
+        'ensure'  => 'installed',
+        'require' => 'Portage::Package[ruby]',
+      })
+      should_not contain_package('rubygems-update')
+      should_not contain_exec('ruby::update_rubygems')
+    }
+  end
 
   describe 'when called with custom rubygems and ruby versions on redhat' do
     let (:facts) { {  :osfamily => 'Redhat',
@@ -149,6 +205,53 @@ describe 'ruby', :type => :class do
       should contain_package('rubygems').with({
         'ensure'  => '1.8.6',
         'require' => 'Package[ruby]',
+      })
+      should_not contain_package('rubygems-update')
+      should_not contain_exec('ruby::update_rubygems')
+    }
+  end
+
+  describe 'when called with custom rubygems and ruby versions on gentoo' do
+    let (:facts) { { :osfamily => 'Gentoo',
+                     :operatingsystem => 'gentoo',
+                      :path     => '/usr/local/bin:/usr/bin:/bin' } }
+    let (:params) { {   :gems_version => '1.9.3_p448',
+                        :version      => '2.0.3', } }
+    it {
+      should contain_portage__package('ruby').with({
+        'ensure'  => '2.0.3',
+        'name'    => 'dev-lang/ruby',
+      })
+      should contain_portage__package('rubygems').with({
+        'ensure'  => '1.9.3_p448',
+        'require' => 'Portage::Package[ruby]',
+      })
+      should_not contain_package('rubygems-update')
+      should_not contain_exec('ruby::update_rubygems')
+    }
+  end
+
+  describe 'when called with keywords and useflags on gentoo' do
+    let (:facts) { { :osfamily => 'Gentoo',
+                     :operatingsystem => 'gentoo',
+                     :path     => '/usr/local/bin:/usr/bin:/bin' } }
+    let (:params) { {   :ruby_gentoo_keywords => ['~amd64', '~x86'],
+                        :ruby_gentoo_use      => ['rdoc', 'readline', 'ssl'],
+                        :gems_gentoo_keywords => ['~amd64', '~x86'],
+                        :gems_gentoo_use      => ['rdoc', 'readline', 'ssl'], } }
+    it {
+      should contain_portage__package('ruby').with({
+        'ensure'   => 'installed',
+        'name'     => 'dev-lang/ruby',
+        'keywords' => ['~amd64', '~x86'],
+        'use'      => ['rdoc', 'readline', 'ssl'],
+      })
+      should contain_portage__package('rubygems').with({
+        'ensure'   => 'installed',
+        'name'     => 'dev-ruby/rubygems',
+        'require'  => 'Portage::Package[ruby]',
+        'keywords' => ['~amd64', '~x86'],
+        'use'      => ['rdoc', 'readline', 'ssl'],
       })
       should_not contain_package('rubygems-update')
       should_not contain_exec('ruby::update_rubygems')


### PR DESCRIPTION
Introduces dependency to gentoo/portage module Package installation happens
with portage::package, in order to handle KEYWORDS and USE flags for the
Gentoo packages for dev-lang/ruby and dev-ruby/rubygems
