### PR TITLE
rubygems1.9.1 is a virtual package pointing to ruby1.9.1 in ubuntu

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -89,10 +89,18 @@ class ruby (
     $rubygems_ensure = $gems_version
   }
 
-  package { 'rubygems':
-    ensure  => $rubygems_ensure,
-    name    => $rubygems_package,
-    require => Package['ruby'],
+  if $rubygems_package == 'rubygems1.9.1' and $::lsbdistid == 'Ubuntu' and  $::lsbmajdistrelease >= 10 {
+    package { 'rubygems':
+        ensure  => $rubygems_ensure,
+        name    => 'ruby1.9.1',
+        require => Package['ruby'],
+    }
+  } else {
+    package { 'rubygems':
+        ensure  => $rubygems_ensure,
+        name    => $rubygems_package,
+        require => Package['ruby'],
+    }
   }
 
   if $rubygems_update {


### PR DESCRIPTION
versions after 10.04.  This hack stops changes being made on every run. 

im sure there is a better way to do this but im new to puppet but thought i would make the request to alert you of the issue.
