### PR TITLE
gem is provided by ruby in Ubuntu Trusty.

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -140,10 +140,12 @@ class ruby (
     $rubygems_ensure = $gems_version
   }
 
-  package { 'rubygems':
-    ensure  => $rubygems_ensure,
-    name    => $rubygems_package,
-    require => Package['ruby'],
+  if !defined(Package[$rubygems_package]) {
+    package { 'rubygems':
+      ensure  => $rubygems_ensure,
+      name    => $rubygems_package,
+      require => Package['ruby'],
+    }
   }
 
   if $rubygems_update {

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -6,17 +6,27 @@ class ruby::params {
   $version              = 'installed'
   $gems_version         = 'installed'
   $ruby_package         = 'ruby'
-  $rubygems_package     = 'rubygems'
   $ruby_switch_package  = 'ruby-switch'
 
   case $::osfamily {
     'redhat', 'amazon': {
       $ruby_dev = ['ruby-devel','rubygems-bundler']
       $rubygems_update = true
+      $rubygems_package = 'rubygems'
     }
     'debian': {
       $ruby_dev = [ 'ruby-dev', 'rake', 'ri', 'ruby-bundler', 'pkg-config' ]
       $rubygems_update = false
+
+      case $::lsbdistcodename {
+        'trusty': {
+          $rubygems_package = 'ruby'
+        }
+
+        default: {
+          $rubygems_package = 'rubygems'
+        }
+      }
     }
     default: {
       fail("Unsupported OS family: ${::osfamily}")

--- a/spec/classes/init_spec.rb
+++ b/spec/classes/init_spec.rb
@@ -68,6 +68,21 @@ describe 'ruby', :type => :class do
     }
   end
 
+  describe 'when called with no parameters on Ubuntu trusty' do
+    let (:facts) { {  :osfamily        => 'Debian',
+                      :lsbdistcodename => 'trusty',
+                      :path            => '/usr/local/bin:/usr/bin:/bin' } }
+    it {
+      should contain_package('ruby').with({
+        'ensure'  => 'installed',
+        'name'    => 'ruby',
+      })
+      should_not contain_package('rubygems')
+      should_not contain_package('rubygems-update')
+      should_not contain_exec('ruby::update_rubygems')
+    }
+  end
+
   describe 'when called with custom rubygems version on redhat' do
     let (:facts) { {   :osfamily  => 'Redhat',
                        :path      => '/usr/local/bin:/usr/bin:/bin' } }


### PR DESCRIPTION
The 'rubygems' package no longer exists in Ubuntu 14.04 LTS 'Trusty'.

This commit adds support for the distinction while keeping backwards compatibility.
