### PR TITLE
simplify array handling

### DIFF
--- a/templates/gemrc.yaml.erb
+++ b/templates/gemrc.yaml.erb
@@ -2,7 +2,7 @@
 # Any modifications will be overwritten on the next run
 <%- if @sources and ! @sources.empty? -%>
 :sources:
-  - <%= [@sources].flatten.compact.join("\n - ") %>
+  - <%= Array(@sources).join("\n - ") %>
 <%- end -%>
 <%- unless @update_sources.nil? -%>
 :update_sources: <%= @update_sources %>
@@ -14,13 +14,13 @@
 :backtrace: <%= @backtrace %>
 <%- end -%>
 <%- if @gempath -%>
-:gempath: <%= [@gempath].flatten.compact.join(':') %>
+:gempath: <%= Array(@gempath).join(':') %>
 <%- end -%>
 <%- unless @disable_default_gem_server.nil? -%>
 :disable_default_gem_server: <%= @disable_default_gem_server  %>
 <%- end -%>
 <%- if @gem_command and ! @gem_command.empty? -%>
 <%-   @gem_command.each do |command,options| -%>
-<%= command %>: --<%= [options].flatten.compact.join(' --') %>
+<%= command %>: --<%= Array(options).join(' --') %>
 <%-   end -%>
 <%- end -%>


### PR DESCRIPTION
pass as argument to `Array()` constructor, rather than `[@a].flatten.compact`
