### PR TITLE
Correct ruby-switch argument when using ruby<VERSION>-full

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -170,9 +170,18 @@ class ruby (
             name    => $ruby::params::ruby_switch_package,
             require => Package['ruby'],
           }
+
+          # The ruby<VERSION>-full package names cannot be used as arguments to
+          # ruby-switch so handle these cases explicitly.
+          $ruby_interpreter = $real_ruby_package ? {
+            'ruby1.8-full'   => 'ruby1.8',
+            'ruby1.9.1-full' => 'ruby1.9.1',
+            default          => $real_ruby_package,
+          }
+
           exec{'switch_ruby':
-            command => "/usr/bin/ruby-switch --set ${real_ruby_package}",
-            unless  => "/usr/bin/ruby-switch --check|/bin/grep ${real_ruby_package}",
+            command => "/usr/bin/ruby-switch --set ${ruby_interpreter}",
+            unless  => "/usr/bin/ruby-switch --check|/bin/grep ${ruby_interpreter}",
             require => Package['ruby-switch'],
           }
         } else {

--- a/spec/classes/init_spec.rb
+++ b/spec/classes/init_spec.rb
@@ -395,4 +395,54 @@ describe 'ruby', :type => :class do
     }
   end
 
+  describe 'when using ruby-switch on Ubuntu earlier than 14.04 and the Ruby package is ruby1.9.1-full' do
+    let (:facts) { {    :osfamily         => 'Debian',
+                        :operatingsystem  => 'Ubuntu',
+                        :lsbdistrelease   => '12.04',
+                        :path             => '/usr/local/bin:/usr/bin:/bin' } }
+    let (:params) { {   :version            => 'installed',
+                        :ruby_package       => 'ruby1.9.1-full',
+                        :switch             => true,
+                        } }
+    it {
+      should contain_package('ruby-switch').with({
+        'ensure'  => 'installed',
+        'name'    => 'ruby-switch',
+        'require' => 'Package[ruby]'
+      })
+    }
+    it {
+      should contain_exec('switch_ruby').with({
+        'command' => '/usr/bin/ruby-switch --set ruby1.9.1',
+        'unless'  => '/usr/bin/ruby-switch --check|/bin/grep ruby1.9.1',
+        'require' => 'Package[ruby-switch]'
+      })
+    }
+  end
+
+  describe 'when using ruby-switch on Ubuntu earlier than 14.04 and the Ruby package is ruby1.8-full' do
+    let (:facts) { {    :osfamily         => 'Debian',
+                        :operatingsystem  => 'Ubuntu',
+                        :lsbdistrelease   => '12.04',
+                        :path             => '/usr/local/bin:/usr/bin:/bin' } }
+    let (:params) { {   :version            => 'installed',
+                        :ruby_package       => 'ruby1.8-full',
+                        :switch             => true,
+                        } }
+    it {
+      should contain_package('ruby-switch').with({
+        'ensure'  => 'installed',
+        'name'    => 'ruby-switch',
+        'require' => 'Package[ruby]'
+      })
+    }
+    it {
+      should contain_exec('switch_ruby').with({
+        'command' => '/usr/bin/ruby-switch --set ruby1.8',
+        'unless'  => '/usr/bin/ruby-switch --check|/bin/grep ruby1.8',
+        'require' => 'Package[ruby-switch]'
+      })
+    }
+  end
+
 end


### PR DESCRIPTION
When setting `ruby::ruby_package => 'ruby1.9.1-full'` (or
`'ruby1.8-full`) the correct argument to `ruby-switch --set` is
`ruby1.9.1` (or `ruby1.8`), not the package name as is. Handle these two
cases explicitly when `ruby::switch` is set. Contains updated spec
tests.
