### PR TITLE
Change the defaults for ruby_package and rubygems_package on ubu 14.04

### DIFF
--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -5,18 +5,30 @@
 class ruby::params {
   $version              = 'installed'
   $gems_version         = 'installed'
-  $ruby_package         = 'ruby'
-  $rubygems_package     = 'rubygems'
   $ruby_switch_package  = 'ruby-switch'
 
   case $::osfamily {
     'redhat', 'amazon': {
-      $ruby_dev = ['ruby-devel','rubygems-bundler']
-      $rubygems_update = true
+      $ruby_dev             = ['ruby-devel','rubygems-bundler']
+      $rubygems_update      = true
+      $ruby_package         = 'ruby'
+      $rubygems_package     = 'rubygems'
     }
     'debian': {
-      $ruby_dev = [ 'ruby-dev', 'rake', 'ri', 'ruby-bundler', 'pkg-config' ]
-      $rubygems_update = false
+      $ruby_dev             = [ 'ruby-dev', 'rake', 'ri', 'ruby-bundler', 'pkg-config' ]
+      $rubygems_update      = false
+      case $::operatingsystemrelease {
+        '14.04': {
+          #Ubuntu 14.04 changed ruby/rubygems to be all in one package. Specifying these as defaults will permit the module to behave as anticipated.
+          $ruby_package     = 'ruby1.9.1'
+          $rubygems_package = 'ruby1.9.1-full'
+        }
+        default: {
+          $ruby_package     = 'ruby'
+          $rubygems_package = 'rubygems'
+        }
+
+      }
     }
     default: {
       fail("Unsupported OS family: ${::osfamily}")

--- a/spec/classes/init_spec.rb
+++ b/spec/classes/init_spec.rb
@@ -100,7 +100,26 @@ describe 'ruby', :type => :class do
       })
     }
   end
-
+  describe 'when called with custom rubygems version on Ubuntu 14.04' do
+    let (:facts) { {   :osfamily  => 'Debian',
+                       :operatingsystemrelease => '14.04',
+                       :path      => '/usr/local/bin:/usr/bin:/bin' } }
+    it {
+      should contain_package('ruby').with({
+        'ensure'  => 'installed',
+        'name'    => 'ruby1.9.1',
+      })
+    }
+    it {
+      should contain_package('rubygems').with({
+        'ensure'  => 'installed',
+        'require' => 'Package[ruby]',
+        'name'    => 'ruby1.9.1-full'
+      })
+    }
+    it {should_not contain_package('rubygems-update')}
+    it {should_not contain_exec('ruby::update_rubygems')}
+  end
   describe 'when called with custom ruby package name' do
     let (:facts) { { :osfamily => 'Debian',
                      :path     => '/usr/local/bin:/usr/bin:/bin' } }


### PR DESCRIPTION
This seems like an elegant way to solve the issue PR30 intends to solve.
