### PR TITLE
Fix package name

### DIFF
--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -26,7 +26,7 @@ class ruby::params {
         'pkg-config'
       ]
       $rake_package     = 'rake'
-      $bundler_package  = 'ruby-bundler'
+      $bundler_package  = 'bundler'
       $bundler_provider = 'apt'
       $rubygems_update  = false
       $ruby_gem_base    = '/usr/bin/gem'

--- a/spec/classes/dev_spec.rb
+++ b/spec/classes/dev_spec.rb
@@ -183,7 +183,7 @@ describe 'ruby::dev', :type => :class do
         it {
           should contain_package('bundler').with({
             'ensure'    => 'installed',
-            'name'      => 'ruby-bundler',
+            'name'      => 'bundler',
             'provider'  => 'apt',
             'require'   => 'Package[ruby]',
           })
@@ -344,7 +344,7 @@ describe 'ruby::dev', :type => :class do
         it {
           should contain_package('bundler').with({
             'ensure'    => 'installed',
-            'name'      => 'ruby-bundler',
+            'name'      => 'bundler',
             'provider'  => 'apt',
             'require'   => 'Package[ruby]',
           })
@@ -506,7 +506,7 @@ describe 'ruby::dev', :type => :class do
         it {
           should contain_package('bundler').with({
             'ensure'    => 'installed',
-            'name'      => 'ruby-bundler',
+            'name'      => 'bundler',
             'provider'  => 'apt',
             'require'   => 'Package[ruby]',
           })
@@ -668,7 +668,7 @@ describe 'ruby::dev', :type => :class do
         it {
           should contain_package('bundler').with({
             'ensure'    => 'installed',
-            'name'      => 'ruby-bundler',
+            'name'      => 'bundler',
             'provider'  => 'apt',
             'require'   => 'Package[ruby]',
           })


### PR DESCRIPTION
The package ruby-bundler does not exist at Debian and in case of Ubuntu it is just a transitional dummy package.
