### PR TITLE
Fix missing params::gem_integration_package

### DIFF
--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -9,6 +9,7 @@ class ruby::params {
   $rails_env               = 'production'
   $minimum_path            = ['/usr/bin', '/bin', '/usr/sbin', '/sbin', '/usr/local/bin']
   $gem_integration_package = false
+  $ruby_dev_gems           = false
 
   case $::osfamily {
     'redhat', 'amazon': {


### PR DESCRIPTION
A recent commit adds $gem_integration_package as a parameter to init.pp, with $ruby::params::gem_integration_package as a default setting. Docs indicate this is set to false by default, but it's never defined in params.pp.

Rake spec passes on this but actual integration tests fail.

This adds the default false spec. Future integration/beaker test PR will address missing this on the first run.
