### PR TITLE
Require ruby2.1-dev when installing 2.1 on Debian

### DIFF
--- a/manifests/dev.pp
+++ b/manifests/dev.pp
@@ -80,7 +80,7 @@ class ruby::dev (
           }
           /^2\.1.*$/:{
             $ruby_dev = [
-              'ruby2.0-dev',
+              'ruby2.1-dev',
               'ri',
               'pkg-config'
             ]

--- a/spec/classes/dev_spec.rb
+++ b/spec/classes/dev_spec.rb
@@ -711,7 +711,7 @@ describe 'ruby::dev', :type => :class do
       end
       context 'with no parameters' do
         it {
-          should contain_package('ruby2.0-dev').with({
+          should contain_package('ruby2.1-dev').with({
             'ensure' => 'installed',
           })
         }
@@ -750,7 +750,7 @@ describe 'ruby::dev', :type => :class do
           }
         end
         it {
-          should contain_package('ruby2.0-dev').with_ensure('latest')
+          should contain_package('ruby2.1-dev').with_ensure('latest')
         }
         it {
           should contain_package('ri').with_ensure('latest')
@@ -786,7 +786,7 @@ describe 'ruby::dev', :type => :class do
           should contain_package('bundler').with_name('sparkly-bundler')
         }
         it {
-          should_not contain_package('ruby2.0-dev')
+          should_not contain_package('ruby2.1-dev')
         }
         it {
           should_not contain_package('ri')


### PR DESCRIPTION
Previously ruby2.0-dev was required when including ruby-dev and installing Ruby 2.1. Ruby can not build native extensions when the correct dev package is missing.
