### PR TITLE
Add FreeBSD 10 support

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@ Puppet v3 with Ruby 1.8.7, 1.9.3, 2.0.0 and 2.1.1 on the following platforms.
 # Dependencies
 
 * [PuppetLabs stdlib](https://forge.puppetlabs.com/puppetlabs/stdlib)
+* [zleslie pkgng](https://forge.puppetlabs.com/zleslie/pkgng) must be installed for FreeBSD support on Puppet versions < 4.1.0
 
 ## Ruby Class
 

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -63,6 +63,22 @@ class ruby::params {
         }
       }
     }
+    'FreeBSD': {
+      $ruby_dev         = [
+        'ruby-build',
+      ]
+      $rake_ensure      = 'installed'
+      $rake_package     = 'rake'
+      $rake_provider    = 'gem'
+      $rubygems_update  = false
+      $ruby_gem_base    = '/usr/local/bin/gem'
+      $ruby_bin_base    = '/usr/local/bin/ruby'
+      $bundler_package  = 'bundler'
+      $bundler_provider = 'gem'
+      $bundler_ensure   = 'installed'
+      $ruby_package     = 'ruby'
+      $rubygems_package = 'ruby20-gems'
+    }
     default: {
       fail("Unsupported OS family: ${::osfamily}")
     }

--- a/metadata.json
+++ b/metadata.json
@@ -41,6 +41,12 @@
       ]
     },
     {
+      "operatingsystem": "FreeBSD",
+      "operatingsystemrelease": [
+        "10"
+      ]
+    },
+    {
       "operatingsystem": "SLES",
       "operatingsystemrelease": [
         "11 SP1"


### PR DESCRIPTION
This updates params.pp with parameters that work with FreeBSD 10, lists FreeBSD 10 support in metadata.json, and adds zleslie/pkgng as a dependency. Without the pkgng module, puppet will try to use the gem provider to install a package named ruby, which obviously fails.

If adding a non-puppetlabs dependency is a problem, I can add a conditional statement in `init.pp` to skip the `ruby` package install if `osfamily == 'FreeBSD'`.

I'm not terribly experienced with FreeBSD, so I'm not sure if setting `$rubygems_package = 'ruby20-gems'` is reasonable. @xaque208 do you mind taking a look?

This is all in support of making [puppet-puppet](https://github.com/puppetlabs-operations/puppet-puppet) work on FreeBSD.