### PR TITLE
Fixed an issue where multiple gem sources generated an invalid YAML file

### DIFF
--- a/templates/gemrc.yaml.erb
+++ b/templates/gemrc.yaml.erb
@@ -2,7 +2,7 @@
 # Any modifications will be overwritten on the next run
 <%- if @sources and ! @sources.empty? -%>
 :sources:
-  - <%= Array(@sources).join("\n - ") %>
+  - <%= Array(@sources).join("\n  - ") %>
 <%- end -%>
 <%- unless @update_sources.nil? -%>
 :update_sources: <%= @update_sources %>


### PR DESCRIPTION
When we supplied multiple sources a YAML file with incorrect white space was generated. This corrects the issue so that users can give more then one source.