### PR TITLE
Fix bundler_package name for ubuntu (provider gem).

### DIFF
--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -43,13 +43,7 @@ class ruby::params {
       $ruby_gem_base    = '/usr/bin/gem'
       $ruby_bin_base    = '/usr/bin/ruby'
       $bundler_provider = 'gem'
-      if $::operatingsystem == 'Ubuntu'
-      and $::operatingsystemrelease
-      and versioncmp($::operatingsystemrelease, '14.04') < 0 {
-        $bundler_package  = 'ruby-bundler'
-      } else {
-        $bundler_package  = 'bundler'
-      }
+      $bundler_package  = 'bundler'
       case $::operatingsystemrelease {
         '10.04': {
           $bundler_ensure   = '0.9.9'

--- a/spec/classes/dev_spec.rb
+++ b/spec/classes/dev_spec.rb
@@ -217,7 +217,7 @@ describe 'ruby::dev', :type => :class do
           it {
             should contain_package('bundler').with({
               'ensure'           => '0.9.9',
-              'name'             => 'ruby-bundler',
+              'name'             => 'bundler',
               'provider'         => 'gem',
               'require'          => 'Package[ruby]'
             })
@@ -235,7 +235,7 @@ describe 'ruby::dev', :type => :class do
           it {
             should contain_package('bundler').with({
               'ensure'           => 'installed',
-              'name'             => 'ruby-bundler',
+              'name'             => 'bundler',
               'provider'         => 'gem',
               'require'          => 'Package[ruby]'
             })


### PR DESCRIPTION
Bundler gem is called bundler on all ubuntu versions.

MODULES-1387 requested to change the name of bundler_package to ruby-bundler on ubuntu systems prior to 14.04. This is correct when using apt as a provider. But the default provider (bundler_provider) was switched to gem with commit 4312bb997edcb6153feb7c0c66cc2dd3d594ebaa and the bundler gem is called 'bundler' on all versions of ubuntu.