### PR TITLE
Remove unused metadata

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -69,14 +69,7 @@
     }
   ],
   "requirements": [
-    {
-      "name": "pe",
-      "version_requirement": ">= 3.2.0 < 5.0.0"
-    },
-    {
-      "name": "puppet",
-      "version_requirement": ">= 3.0.0 < 5.0.0"
-    }
+    {"name":"puppet", "version_requirement": ">= 3.0.0 < 5.0.0" }
   ],
   "dependencies": [
     {"name":"puppetlabs/stdlib","version_requirement":">= 4.6.0 < 6.0.0"}


### PR DESCRIPTION
Removes PE information from supported versions of Puppet as per David
Schmitt's request.