### PR TITLE
Update params.pp for FreeBSD 11

### DIFF
--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -77,7 +77,14 @@ class ruby::params {
       $bundler_provider = 'gem'
       $bundler_ensure   = 'installed'
       $ruby_package     = 'ruby'
-      $rubygems_package = 'ruby20-gems'
+      case $::operatingsystemmajrelease {
+        '11': {
+          $rubygems_package = 'ruby22-gems'
+        }
+        default: {
+          $rubygems_package = 'ruby20-gems'
+        }
+      }
     }
     default: {
       fail("Unsupported OS family: ${::osfamily}")


### PR DESCRIPTION
FreeBSD 11 requires rubygems package version 22, as apposed to all previous supported FreeBSD versions.  We tested this locally, wanted to update the rest of the world.  FreeBSD 11, if pattern holds, should stick with this package for the entirety of 11's life