### PR TITLE
Make managing rubygems optional

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -96,6 +96,7 @@ class ruby (
   $ruby_package             = $ruby::params::ruby_package,
   $ruby_dev_packages        = $ruby::params::ruby_dev,
   $rubygems_package         = $ruby::params::rubygems_package,
+  $manage_rubygems          = $ruby::params::manage_rubygems,
   $suppress_warnings        = false,
   $set_system_default       = false,
   $system_default_bin       = undef,
@@ -173,24 +174,26 @@ class ruby (
     $rubygems_ensure = $gems_version
   }
 
-  package { 'rubygems':
-    ensure  => $rubygems_ensure,
-    name    => $rubygems_package,
-    require => Package['ruby'],
-  }
-
-  if $rubygems_update {
-    package { 'rubygems-update':
-      ensure   => $gems_version,
-      provider => 'gem',
-      require  => Package['rubygems'],
-      notify   => Exec['ruby::update_rubygems'],
+  if $manage_rubygems {
+    package { 'rubygems':
+      ensure  => $rubygems_ensure,
+      name    => $rubygems_package,
+      require => Package['ruby'],
     }
 
-    exec { 'ruby::update_rubygems':
-      path        => '/usr/local/bin:/usr/bin:/bin',
-      command     => 'update_rubygems',
-      refreshonly => true,
+    if $rubygems_update {
+      package { 'rubygems-update':
+        ensure   => $gems_version,
+        provider => 'gem',
+        require  => Package['rubygems'],
+        notify   => Exec['ruby::update_rubygems'],
+      }
+
+      exec { 'ruby::update_rubygems':
+        path        => '/usr/local/bin:/usr/bin:/bin',
+        command     => 'update_rubygems',
+        refreshonly => true,
+      }
     }
   }
 

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -10,6 +10,7 @@ class ruby::params {
   $minimum_path            = ['/usr/bin', '/bin', '/usr/sbin', '/sbin', '/usr/local/bin']
   $gem_integration_package = false
   $ruby_dev_gems           = false
+  $manage_rubygems         = true
 
   case $::osfamily {
     'redhat', 'amazon': {


### PR DESCRIPTION
Debian Jessie has a virtual package for Rubygems which means every puppet run the virtual package is re-installed.  Adding the option to manage Rubygems allows me to switch this off with hiera data