### PR TITLE
Allow yum as bundler provider

### DIFF
--- a/manifests/dev.pp
+++ b/manifests/dev.pp
@@ -42,7 +42,7 @@ class ruby::dev (
   $rake_provider                                            = $ruby::params::rake_provider,
   $bundler_ensure                                           = $ruby::params::bundler_ensure,
   $bundler_package                                          = $ruby::params::bundler_package,
-  Enum['gem', 'apt', 'pacman'] $bundler_provider            = $ruby::params::bundler_provider,
+  Enum['yum', 'gem', 'apt', 'pacman'] $bundler_provider     = $ruby::params::bundler_provider,
 ) inherits ruby::params {
   require ::ruby
 


### PR DESCRIPTION
Software Collection (for CentOS and RHEL) repositories provides bundler as a OS package, in yum/rpm format.

The documentation should be updated to reflect this change.