### PR TITLE
Make it explicit that this module is compatible with Puppet 5

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -70,7 +70,7 @@
     }
   ],
   "requirements": [
-    {"name":"puppet", "version_requirement": ">= 4.7.0 < 5.0.0" }
+    {"name":"puppet", "version_requirement": ">= 4.7.0 < 6.0.0" }
   ],
   "dependencies": [
     {


### PR DESCRIPTION
Without this change Kafo-based installers need to be forced to load this module
with --skip-puppet-version-check. Other software that parses version
requirements in metadata.json may have similar issues.