### PR TITLE
switch to ensure_packages()

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -158,10 +158,7 @@ class ruby (
   # available. It's a bit misleading for the user, though, since they can
   # specify a version and it will just silently continue installing the
   # default version.
-  package { 'ruby':
-    ensure => $ruby_package_ensure,
-    name   => $real_ruby_package,
-  }
+  ensure_packages(['ruby'], {ensure => $ruby_package_ensure, 'name' => $real_ruby_package })
 
   # if rubygems_update is set to true then we only need to make the package
   # resource for rubygems ensure to installed, we'll let rubygems-update


### PR DESCRIPTION
The ruby module is used as a dependency in many other component modules.
Some of them also define the `ruby` package or any of the other packages
here. This leads to duplicate resources and a failing catalog. As a
workaround I migrated all package resources to `ensure_packages()` from
stdlib and increased the minimal stdlib version from 4.13.1 to 4.19.0.