### PR TITLE
Add support for LinuxMint 19

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,7 @@ Puppet >= 4.7.0 with Ruby 2.1.9 and 2.4.1 on the following platforms.
   * FreeBSD 10
   * SLES 11 SP1
   * Arch Linux
+  * LinuxMint 19
 
 
 # Dependencies

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -56,27 +56,42 @@ class ruby::params {
       $ruby_bin_base    = '/usr/bin/ruby'
       $bundler_provider = 'gem'
       $bundler_package  = 'bundler'
-      case $::operatingsystemrelease {
-        '10.04': {
-          $bundler_ensure   = '0.9.9'
-          $ruby_package     = 'ruby'
-          $rubygems_package = 'rubygems'
-        }
-        '14.04': {
-          #Ubuntu 14.04 changed ruby/rubygems to be all in one package. Specifying these as defaults will permit the module to behave as anticipated.
-          $bundler_ensure   = 'installed'
-          $ruby_package     = 'ruby'
-          $rubygems_package = 'ruby1.9.1-full'
-        }
-        '18.04': {
-          $bundler_ensure   = 'installed'
-          $ruby_package     = 'ruby-full'
-          $rubygems_package = 'rubygems'
+      case $::facts['os']['name'] {
+        /LinuxMint/: {
+          case $::facts['os']['release']['major'] {
+            '19': {
+              $bundler_ensure   = 'installed'
+              $ruby_package     = 'ruby'
+              $rubygems_package = undef
+            }
+            default: {
+              $bundler_ensure   = 'installed'
+              $ruby_package     = 'ruby'
+              $rubygems_package = 'rubygems'
+            }
+          }
         }
         default: {
-          $bundler_ensure   = 'installed'
-          $ruby_package     = 'ruby'
-          $rubygems_package = 'rubygems'
+          case $::operatingsystemrelease {
+            '10.04': {
+              $bundler_ensure   = '0.9.9'
+              $ruby_package     = 'ruby'
+              $rubygems_package = 'rubygems'
+            }
+            '14.04': {
+              # Ubuntu 14.04 changed ruby/rubygems to be all in one package.
+              # Specifying these as defaults will permit the module to behave
+              # as anticipated.
+              $bundler_ensure   = 'installed'
+              $ruby_package     = 'ruby'
+              $rubygems_package = 'ruby1.9.1-full'
+            }
+            default: {
+              $bundler_ensure   = 'installed'
+              $ruby_package     = 'ruby'
+              $rubygems_package = 'rubygems'
+            }
+          }
         }
       }
     }


### PR DESCRIPTION
In LinuxMint, `rubygems` is integrated into the `ruby` package.